### PR TITLE
Update service-monitor.yaml

### DIFF
--- a/src/main/resources/k8s/helm/c7-load-test/templates/service-monitor.yaml
+++ b/src/main/resources/k8s/helm/c7-load-test/templates/service-monitor.yaml
@@ -6,9 +6,14 @@ metadata:
   labels: {{- include "c7-load-test.labels" . | nindent 4 }}
     {{- toYaml .Values.prometheusServiceMonitor.labels | nindent 4}}
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "c7-load-test.labels" . | nindent 4 }}
+      app.kubernetes.io/name: {{ include "c7-load-test.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+
   endpoints:
     - honorLabels: true
       path: /actuator/prometheus


### PR DESCRIPTION
No more warnings and should work with helm version > 3.9